### PR TITLE
feat: notation enhancement, fixes #9

### DIFF
--- a/src/pages/notation.typ
+++ b/src/pages/notation.typ
@@ -6,6 +6,8 @@
 /// - width (length | relative): The width of the notation grid.
 /// - columns (array): The widths of the grid columns for terms and descriptions.
 /// - row-gutter (length): The vertical space between rows.
+/// - chunked (bool): Whether to chunk the content by parbreaks.
+/// - blank-row-gutter (length | none): The vertical space for blank rows, defaults to `row-gutter * 2` if not specified.
 /// - args (dictionary): Additional arguments for the grid layout.
 /// - it (content): The content of the notation page.
 /// -> content
@@ -18,34 +20,36 @@
   width: 100%,
   columns: (96pt, 1fr),
   row-gutter: 12pt,
+  chunked: false,
+  blank-row-gutter: none,
   ..args,
   // self
   it,
 ) = {
+  assert(type(row-gutter) == length, message: "row-gutter must be a length value here.")
+
+  let blank-row-gutter = if blank-row-gutter == none { 1.5 * row-gutter }
+
+  let blank-row-inset = if chunked { (blank-row-gutter - 2 * row-gutter) / 2 } else { -row-gutter / 2 }
+
   pagebreak(weak: true, to: if twoside { "odd" })
 
-  heading(
-    level: 1,
-    numbering: none,
-    outlined: outlined,
-    title,
-  )
+  heading(level: 1, numbering: none, outlined: outlined, title)
 
-  align(
-    center,
-    block(
-      width: width,
-      align(
-        start,
-        grid(
-          columns: columns,
-          row-gutter: row-gutter,
-          ..args,
-          ..it.children.filter(it => it.func() == terms.item).map(it => (it.term, it.description)).flatten()
-        ),
-      ),
-    ),
-  )
+  align(center, block(width: width, align(start, grid(
+    columns: columns,
+    row-gutter: row-gutter,
+    ..args,
+    ..it
+      .children
+      .filter(it => it.func() == parbreak or it.func() == terms.item)
+      .map(it => if (it.func() == parbreak) {
+        grid.cell(none, colspan: 2, inset: (y: blank-row-inset))
+      } else { (it.term, it.description) }) // terms.item
+      .flatten()
+  ))))
 
+  /// Notation page is the last page of the front matter,
+  /// so we need to ensure it ends with a page break before the main matter in two-sided mode.
   if twoside { pagebreak() + " " }
 }


### PR DESCRIPTION
After some research, i have found that the behavior of term list items (line height) in markup mode is affected by par break (seemingly for better layout, not a bug), thus it will be inevitable to continue using grid to set the line height forced.

In the grid, empty rows will be collapsed, causing the space between the rows above and below to become twice the row gutter, while empty items in markup mode will behave similarly to par break line spacing.

Considering that blank term list items are an uncommon writing style (`/ :`), this PR introduces par break (which is a more naturally writing style) to simulate this behavior, while also introducing a chunked option to indicate whether to enable this behavior (disabled by default).

Note that the behavior of blank term items is not overridden, thus writing them will introduce double row gutter, which is not recommended.