### PR TITLE
fix: potential problem in v5.3.0

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
   assert(degree in ("bachelor", "master", "doctor", "postdoc"), message: "不支持的学位")
   assert(degree-type in ("academic",), message: "不支持的学位类型")
 
-  anonymous = is-true(anonymous)
+  anonymous = if anonymous in (true, "true") { true } else { false }
 
   if type(info.title) == str { info.title = info.title.split("\n") } else {
     assert(type(info.title) == array, message: "论文标题（info.title）必须是字符串或字符串数组")

--- a/src/pages/cover.typ
+++ b/src/pages/cover.typ
@@ -47,24 +47,23 @@
   let use-cjk-fonts = name => _use-cjk-fonts(fonts, name)
   let use-anonymous = width => block(width: width, fill: black, "", outset: (y: 2pt))
 
-  // @typstyle off
-  let preset-info-items = (
-    bachelor: (department: "系别", major: "专业", author: "姓名", supervisor: "指导教师"),
-    graduate: (department: "培养单位", major: "学科", author: "研究生", supervisor: "指导教师", co-supervisor: "联合指导教师"),
-  )
+  let has-co-supervisor = info.at("co-supervisor", default: none) not in (none, ())
 
-  if info-items == (:) {
-    info-items = if degree == "bachelor" { preset-info-items.bachelor } else { preset-info-items.graduate }
-  }
+  // @typstyle off
+  info-items = (
+    department: "系别", major: "专业", author: "姓名", supervisor: "指导教师",
+    ..if has-co-supervisor { (co-supervisor: "联合指导教师") },
+    ..info-items,
+  )
 
   assert(
     info-items.keys().all(k => k in info),
-    message: "Required info-items for info:" + info-items.keys().filter(k => k not in info).join(", "),
+    message: "Required info-items for info: " + info-items.keys().filter(k => k not in info).join(", "),
   )
 
   // Calculate suitable width of info items
   info-item-width = if info-item-width == none {
-    if degree == "bachelor" { 4em } else { 5em }
+    if has-co-supervisor { 5em } else { 4em }
   } else if info-item-width == auto {
     calc.max(info-items.values().map(v => v.clusters().len())) * 1em
   } else { info-item-width }
@@ -75,43 +74,42 @@
   )
 
   info.supervisor = info.supervisor.chunks(2)
-  if degree != "bachelor" { info.co-supervisor = info.co-supervisor.chunks(2) }
+  if has-co-supervisor { info.co-supervisor = info.co-supervisor.chunks(2) }
 
   // Calculate suitable width of supervisor
   let supervisor-width = {
     let name-width = calc.max(
       info.author.clusters().len(),
       ..info.supervisor.map(p => p.first().clusters().len()),
-      ..if degree != "bachelor" { info.co-supervisor.map(p => p.first().clusters().len()) },
+      ..if has-co-supervisor { info.co-supervisor.map(p => p.first().clusters().len()) },
     )
     let post-width = calc.max(
       ..info.supervisor.map(p => p.last().clusters().len()),
-      ..if degree != "bachelor" { info.co-supervisor.map(p => p.last().clusters().len()) },
+      ..if has-co-supervisor { info.co-supervisor.map(p => p.last().clusters().len()) },
     )
 
-    if name-width <= 3 and post-width >= 4 { (3em, (post-width + 1) * 1em) } else {
-      (calc.max(4, name-width) * 1em, calc.max(4, post-width + 1) * 1em)
+    if name-width <= 2 and info.supervisor.all(p => p.first().clusters().len() < p.last().clusters().len()) {
+      (3em, calc.max(4, post-width) * 1em)
+    } else {
+      (calc.max(4, name-width) * 1em, calc.max(3, post-width) * 1em)
     }
   }
 
-  // TODO: add pretty formatting
   info.author = if anonymous { use-anonymous(4em) } else {
     block(fixed-text(info.author, supervisor-width.first()), width: supervisor-width.first())
   }
 
   let format-supervisor(arr) = arr
     .intersperse("")
-    .map(p => if p == "" { ("", "") } else {
-      if anonymous { use-anonymous(8em) } else {
-        block(
-          fixed-text(p.first(), supervisor-width.first()) + fixed-text("　" + p.last(), supervisor-width.last()),
-          width: supervisor-width.sum(),
-        )
-      }
+    .map(p => if p == "" { ("", "") } else if anonymous { use-anonymous(8em) } else {
+      block(
+        fixed-text(p.first(), supervisor-width.first()) + "　" + fixed-text(p.last(), supervisor-width.last()),
+        width: supervisor-width.sum() + 1em,
+      )
     })
   info.supervisor = format-supervisor(info.supervisor)
 
-  if degree != "bachelor" { info.co-supervisor = format-supervisor(info.co-supervisor) }
+  if has-co-supervisor { info.co-supervisor = format-supervisor(info.co-supervisor) }
 
   let placed-top(content, dy) = place(center + top, content, dy: dy)
   let placed-bottom(content, dy) = place(center + bottom, content, dy: dy)

--- a/src/utils/util.typ
+++ b/src/utils/util.typ
@@ -7,12 +7,6 @@
 /// -> any
 #let array-at(arr, pos) = { arr.at(calc.min(pos, arr.len()) - 1) }
 
-/// Check if a string value represents a true boolean value.
-///
-/// - s (bool, str, content): The string to check
-/// -> bool
-#let is-true(s) = if s in (true, false) { s } else { lower(s) in ("true", "yes", "on", "1") }
-
 /// Check if a value is not empty (not none, not an empty string, and not an empty array).
 ///
 /// - c (any): The value to check
@@ -41,12 +35,18 @@
 /// - args (arguments): The arguments to pass to the pagebreak function
 /// -> none
 #let twoside-pagebreak(twoside, ..args) = {
-  if twoside in (false, "false", "no", "off") { pagebreak(weak: true, ..args) + return }
+  twoside = if twoside in (true, "true") { "no-content" } else { twoside }
 
-  set page(header: none) if twoside in (true, "no-header", "no-content", "default", "true", "yes", "on")
+  if twoside in (false, "false") { return pagebreak(weak: true, ..args) }
+
+  set page(header: none) if twoside in ("no-header", "no-content")
   set page(numbering: none) if twoside in ("no-numbering", "no-content")
-  if twoside in ("no-numbering", "no-content") { counter(page).update(n => n - 1) }
+
   pagebreak(weak: true, to: { "odd" }, ..args)
+
+  if twoside in ("no-numbering",) {
+    counter(page).update(n => calc.max(n - 1, 1))
+  }
 }
 
 /// Filter out specified fields from an element's fields and return a new dictionary with the remaining fields.

--- a/src/utils/util.typ
+++ b/src/utils/util.typ
@@ -43,10 +43,6 @@
   set page(numbering: none) if twoside in ("no-numbering", "no-content")
 
   pagebreak(weak: true, to: { "odd" }, ..args)
-
-  if twoside in ("no-numbering",) {
-    counter(page).update(n => calc.max(n - 1, 1))
-  }
 }
 
 /// Filter out specified fields from an element's fields and return a new dictionary with the remaining fields.

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -100,9 +100,13 @@
     supervisor: ("某某某", "教授"),
     // 多指导老师示例
     // supervisor: ("某某某", "教授", "某某", "副教授"),
-    // 联合指导教师/副指导教师，对本科生无效
-    co-supervisor: ("某某某", "教授"),
+    // 联合指导教师/副指导教师，通常本科生不填写
+    co-supervisor: none,
+    // co-supervisor: ("某某某", "教授"),
   ),
+  // 将 co-supervisor 显示为副指导教师而非联合指导教师
+  // department, major, author, supervisor 也可用类似方式调整
+  // info-items: (co-supervisor: "副指导教师"),
 )
 
 // 英文封面页，仅适用于研究生及以上

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -59,12 +59,20 @@
   // 模板内容会根据学位自动调整，对于不需要的内容会自动忽略
   degree: "bachelor",
   degree-type: "academic",
-  anonymous: false, // 盲审模式
-  twoside: false, // 双面模式，会加入空白页，便于打印
+  // 盲审模式，启用后会隐藏作者信息和部分页面
+  anonymous: false,
+  // 双面模式，会在部分页面后加入空白页，便于打印
+  // 启用双面打印时，可选值: no-header, no-numbering, no-content
+  // - no-header: 不显示页眉
+  // - no-numbering: 不显示页码
+  // - no-content: 不显示页眉和页码（默认为此）
+  // 启用双面打印时，仍然会在空白页上更新页码计数器，如果需要禁用此行为（不建议）
+  // 请在最终文档中的空白页后添加 counter(page).update(n => n - 1)
+  twoside: false,
   // 如下的信息会写入到 PDF 元数据中
   info: (
     title: "清华大学学位论文 Typst 模板\n使用示例文档",
-    // 等价于（如果你需要将标题用 content 表示，请用下面的写法）
+    // 等价于
     // title: ("清华大学学位论文 Typst 模板", "使用示例文档"),
     author: "某某某",
     // 论文提交日期，封面仅显示年月，但具体日期会写入到 PDF 元数据中


### PR DESCRIPTION
- [x] pretty format for the cover's info keys
- [x] page numbering for `no-numbering` twoside printing mode

---

besides, the default behavior of twoside printing mode is changed from `no-header` to `no-content`, also, the optional value of twoside and anonymous are reduced for more concise hint.

for the cover page, the restriction of co-supervisor for bachelor has been removed as sometimes them might use this item